### PR TITLE
feat: export xterm types

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
 import XTerm from './XTerm'
 
 export { XTerm }
+export type * from 'xterm'


### PR DESCRIPTION
fixes #25

Note that the syntax `export types *` needs TS 5